### PR TITLE
Adds a Snyk badge to show you are vulnerability-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ RapydScript
 [![Build Status](https://api.travis-ci.org/kovidgoyal/rapydscript-ng.svg)](https://travis-ci.org/kovidgoyal/rapydscript-ng)
 [![Downloads](https://img.shields.io/npm/dm/rapydscript-ng.svg)](https://www.npmjs.com/package/rapydscript-ng)
 [![Current Release](https://img.shields.io/npm/v/rapydscript-ng.svg)](https://www.npmjs.com/package/rapydscript-ng)
+[![Known Vulnerabilities](https://snyk.io/test/github/kovidgoyal/rapydscript-ng/badge.svg)](https://snyk.io/test/github/kovidgoyal/rapydscript-ng)
 
 This is a fork of the original RapydScript that adds many new (not always
 backwards compatible) features. For more on the forking, [see the bottom of this file](#reasons-for-the-fork)


### PR DESCRIPTION
[rapydscript-ng](https://snyk.io/test/github/kovidgoyal/rapydscript-ng?utm_source=gh_badge) has no vulnerabilities, which is awesome!

This PR adds a badge that shows that you're free of known vulnerabilities. Note that the badge works off the latest master branch.

Adding the badge will show others that you care about security, and that they should care too.
(It will also help to spread the word about Snyk, which would help us out!).

Check our [documentation](https://snyk.io/docs/badges/#github-badge?utm_source=gh_badge) if you'd like to know more about our badges.

Stay secure :-)
Ben from the Snyk team
<!--
snyk:metadata:
-->